### PR TITLE
deps: bump httparty to 0.22

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     logsnag-ruby (0.1.0)
-      httparty (~> 0.21.0)
+      httparty (~> 0.22.0)
 
 GEM
   remote: https://rubygems.org/
@@ -14,10 +14,12 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
+    csv (3.3.0)
     diff-lcs (1.5.1)
     docile (1.4.0)
     hashdiff (1.1.0)
-    httparty (0.21.0)
+    httparty (0.22.0)
+      csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
     json (2.6.3)

--- a/logsnag.gemspec
+++ b/logsnag.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/master/CHANGELOG.md"
 
-  spec.add_dependency "httparty", "~> 0.21.0"
+  spec.add_dependency "httparty", "~> 0.22.0"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
This bumps the dependency `httparty` to the latest version `0.22.0`, which clears out a warning about `csv` no longer being part of the default gems as of Ruby 3.4.0. Info here: https://github.com/jnunemaker/httparty/issues/797