### PR TITLE
Bump httparty to 0.24

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     logsnag-ruby (0.1.1)
-      httparty (~> 0.22.0)
+      httparty (~> 0.24.0)
 
 GEM
   remote: https://rubygems.org/
@@ -18,7 +18,7 @@ GEM
     diff-lcs (1.5.1)
     docile (1.4.0)
     hashdiff (1.1.0)
-    httparty (0.22.0)
+    httparty (0.24.0)
       csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)

--- a/logsnag.gemspec
+++ b/logsnag.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/master/CHANGELOG.md"
 
-  spec.add_dependency "httparty", "~> 0.22.0"
+  spec.add_dependency "httparty", "~> 0.24.0"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
This updates the httparty dependency to 0.24 to address https://github.com/jnunemaker/httparty/security/advisories/GHSA-hm5p-x4rq-38w4